### PR TITLE
Improve search stability and prompt safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ coverage/
 .history
 
 .npmignore
+
+package-lock.json

--- a/src/chunking/semantic-chunker.ts
+++ b/src/chunking/semantic-chunker.ts
@@ -1,6 +1,7 @@
 import { analyzeCodeSize, batchAnalyzeCodeSize, type CodeSizeAnalysis } from './token-counter.js';
 import type { ModelProfile } from '../providers/base.js';
 import { getSizeLimits } from '../providers/base.js';
+import { CHUNKING_CONSTANTS } from '../config/constants.js';
 import type { TreeSitterNode } from '../types/ast.js';
 
 interface LanguageRule {
@@ -200,8 +201,9 @@ export async function yieldStatementChunks(
         unit: profile.useTokens ? 'tokens' : 'characters'
       });
       
-      // Use the provided overlapSize parameter instead of hardcoded 20%
-      const overlapRatio = Math.min(1, Math.max(0, overlapSize / maxSize));
+      const ratioFromConfig = Math.min(1, Math.max(0, CHUNKING_CONSTANTS.LINE_OVERLAP_PERCENTAGE));
+      const ratioFromParam = maxSize > 0 ? Math.min(1, Math.max(0, overlapSize / maxSize)) : 0;
+      const overlapRatio = ratioFromConfig > 0 ? ratioFromConfig : ratioFromParam;
       const overlapLines = Math.max(1, Math.floor(currentChunk.length * overlapRatio));
       currentChunk = currentChunk.slice(-overlapLines);
       currentSize = profile.useTokens && profile.tokenCounter

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -27,7 +27,6 @@ export class CodeVaultDatabase {
   private db: Database.Database;
   private insertChunkStmt!: Database.Statement;
   private getChunksStmt!: Database.Statement;
-  private deleteChunksStmt: Database.Statement | null = null;
   private initialized = false;
 
   constructor(dbPath: string) {
@@ -227,10 +226,8 @@ export class CodeVaultDatabase {
 
     try {
       const placeholders = chunkIds.map(() => '?').join(', ');
-      if (!this.deleteChunksStmt) {
-        this.deleteChunksStmt = this.db.prepare(`DELETE FROM code_chunks WHERE id IN (${placeholders})`);
-      }
-      this.deleteChunksStmt.run(...chunkIds);
+      const deleteStmt = this.db.prepare(`DELETE FROM code_chunks WHERE id IN (${placeholders})`);
+      deleteStmt.run(...chunkIds);
     } catch (error) {
       log.error('Failed to delete chunks', error, { count: chunkIds.length });
       throw error;

--- a/src/ranking/symbol-boost.ts
+++ b/src/ranking/symbol-boost.ts
@@ -215,8 +215,10 @@ export function applySymbolBoost(results: SearchResult[], { query, codemap }: { 
     if (boost > 0) {
       const cappedBoost = Math.min(boost, MAX_SYMBOL_BOOST);
       const baseScore = typeof result.score === 'number' ? result.score : 0;
-      result.score = baseScore + cappedBoost;
-      result.symbolBoost = cappedBoost;
+      const boostedScore = Math.min(1, baseScore + cappedBoost);
+      const appliedBoost = boostedScore - baseScore;
+      result.score = boostedScore;
+      result.symbolBoost = appliedBoost;
       result.symbolBoostSources = sources;
     }
   }


### PR DESCRIPTION
## Summary
- fix database chunk deletion and align caches/overlap constants
- clamp boosted scores and harden prompt + search config usage

## Testing
- npm run build
- node dist/cli.js index --verbose
- node dist/cli.js search "indexer" --limit 3
- node dist/cli.js search-with-code "indexer" --limit 2
- node dist/cli.js ask "What does the update command do?" --max-chunks 2 --reranker off --citations
