### PR TITLE
Phase 1: Fix encryption error surfacing and chunk overlap enforcement

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -98,6 +98,18 @@ export interface SearchCodeResult {
     enabled: boolean;
     boosted: boolean;
   };
+  chunkLoadingFailures?: {
+    totalAttempted: number;
+    failed: number;
+    reasons: {
+      encryption_key_required?: number;
+      encryption_auth_failed?: number;
+      chunk_decompression_failed?: number;
+      chunk_read_failed?: number;
+      file_not_found?: number;
+    };
+  };
+  warnings?: string[];
   results: SearchResult[];
   error?: string;
   message?: string;


### PR DESCRIPTION
## Summary

This PR addresses 2 Phase 1 issues to improve error visibility and chunk overlap consistency. Users will now see actionable warnings when encrypted chunks can't be loaded, and chunk overlap will consistently maintain ≥20% for better search quality.

## Issues Closed

Closes #14  
Closes #15  

## Changes

### 🔐 Encryption Error Surfacing (#14)

**Problem**: Encryption errors were silently swallowed during chunk loading, causing incomplete answers without user awareness.

**Solution**: Track chunk loading failures and surface them with actionable warnings.

#### Modified Files
- **src/core/types.ts**: Added `chunkLoadingFailures` and `warnings` to `SearchCodeResult`
- **src/core/SearchService.ts**:
  - Track chunk loading failures by error code (encryption_key_required, encryption_auth_failed, file_not_found, etc.)
  - Generate user-friendly warnings with remediation steps
  - Reset stats at the start of each search
  - Include failure metadata and warnings in search results

#### User Impact
Users now receive clear warnings when chunks fail to load:
```
Warning: Could not load 5 encrypted chunk(s). Set CODEVAULT_ENCRYPTION_KEY 
environment variable to access encrypted chunks.
```

Metadata includes:
```json
{
  "chunkLoadingFailures": {
    "totalAttempted": 10,
    "failed": 5,
    "reasons": {
      "encryption_key_required": 5
    }
  },
  "warnings": ["Could not load 5 encrypted chunk(s)..."]
}
```

### 📏 Chunk Overlap Enforcement (#15)

**Problem**: Fallback chunking calculated overlap by line count, causing degradation to 1-2% for large chunks instead of documented 20%.

**Solution**: Calculate overlap by token/character count to maintain ≥20% consistently.

#### Modified Files
- **src/chunking/semantic-chunker.ts**:
  - Changed `yieldStatementChunks` to use size-based overlap
  - Added `MIN_OVERLAP_RATIO` constant (0.2)
  - Walk backwards through lines accumulating target overlap size
  - Ensures minimum 20% overlap by tokens/characters

#### Technical Details

**Before (line-based)**:
```typescript
const overlapRatio = Math.min(1, Math.max(0, overlapSize / maxSize));
const overlapLines = Math.max(1, Math.floor(currentChunk.length * overlapRatio));
// Could result in 1-2% overlap for large chunks
```

**After (size-based)**:
```typescript
const MIN_OVERLAP_RATIO = 0.2;
const targetOverlapSize = Math.max(
  overlapSize,
  Math.floor(maxSize * MIN_OVERLAP_RATIO)
);

// Walk backwards accumulating lines until target size reached
for (let i = currentChunk.length - 1; i >= 0 && overlapAccumulatedSize < targetOverlapSize; i--) {
  const lineSize = await profile.tokenCounter(currentChunk[i]);
  overlapAccumulatedSize += lineSize;
  linesToKeep++;
}
```

#### User Impact
- Consistent 20% overlap across all chunk sizes
- Better context continuity in search results
- Improved search quality for large functions/classes
- Behavior now matches documentation

## Testing

All changes have been locally tested:

✅ **Build**: `npm run build` - Zero TypeScript errors  
✅ **Indexing**: Successfully indexed test directory (8 chunks)  
✅ **Search**: Returns results without errors  
✅ **Ask**: Generates answers without errors  

Test artifacts (.codevault, codemap.json) cleaned up before commit.

## Implementation Notes

### Encryption Error Tracking
- Errors are tracked per-search (stats reset at search start)
- Each chunk load attempt increments `totalAttempted`
- Failures increment `failed` and track reason by error code
- Warnings generated only when failures > 0
- Backward compatible - warnings/failures optional in response

### Overlap Calculation
- Uses same token counter as chunk size calculation for consistency
- Falls back to character count if tokens unavailable
- Minimum 1 line always kept for overlap (safety)
- Efficient - single backward pass through lines

## Next Steps

After this PR is merged:
- Phase 1 remaining: #18, #19, #20 (refactoring issues)
- Phase 2: Architectural refactors
- Phase 3: Performance optimizations

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>