### PR TITLE
Add BM25 prefilter for vector search candidates

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -53,6 +53,9 @@ export const SEARCH_CONSTANTS = {
   /** Maximum search results limit */
   MAX_SEARCH_LIMIT: 200,
 
+  /** Maximum BM25 candidates to score with vectors */
+  BM25_PREFILTER_LIMIT: parseInt(process.env.CODEVAULT_BM25_PREFILTER_LIMIT || '500', 10),
+
   /** Selection budget multiplier for hybrid search */
   SELECTION_BUDGET_MULTIPLIER: 60,
 


### PR DESCRIPTION
## Summary
- prefilter search candidates using BM25 to avoid scoring entire corpus
- reuse cached BM25 index and restrict vector scoring to top candidates
- surface candidate cap via constants for tuning

Closes #22