### PR TITLE
Reuse warmed search state across queries

### DIFF
--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -23,6 +23,10 @@ export async function getChunk(sha: string, workingPath?: string): Promise<GetCh
   return await searchService.getChunk(sha, workingPath);
 }
 
+export async function warmupSearch(workingPath?: string, provider?: string): Promise<void> {
+  await searchService.warmup(workingPath, provider);
+}
+
 export function clearSearchCaches(): void {
   searchService.clearCaches();
 }


### PR DESCRIPTION
## Summary
- add SearchService warmup path that reuses context per workspace
- cache database chunks and parsed embeddings across queries with mtime checks
- refresh codemap on change so warmed state stays current

Closes #23