### PR TITLE
Parallelize indexing with controlled concurrency

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -38,6 +38,14 @@ export const CACHE_CONSTANTS = {
 } as const;
 
 /**
+ * Indexing Configuration
+ */
+export const INDEXING_CONSTANTS = {
+  /** Number of files to process in parallel during indexing */
+  DEFAULT_CONCURRENCY: parseInt(process.env.CODEVAULT_INDEXING_CONCURRENCY || '8', 10),
+} as const;
+
+/**
  * Search Configuration
  */
 export const SEARCH_CONSTANTS = {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -8,6 +8,7 @@ export interface IndexProjectOptions {
   deletedFiles?: string[];
   embeddingProviderOverride?: EmbeddingProvider | null;
   encryptMode?: string;
+  concurrency?: number;
 }
 
 export interface IndexProjectResult {


### PR DESCRIPTION
## Summary
- add configurable indexing concurrency (default 8) to process files in parallel
- run file processing with a bounded worker queue while keeping batch writes serialized
- keep sequential delete/finalization while honoring partial updates

Closes #25