### PR TITLE
Index JSON and shell files by default

### DIFF
--- a/src/utils/scan-patterns.ts
+++ b/src/utils/scan-patterns.ts
@@ -21,8 +21,7 @@ export const DEFAULT_SCAN_IGNORES = [
   '**/package-lock.json',
   '**/yarn.lock',
   '**/pnpm-lock.yaml',
-  '**/*.json',
-  '**/*.sh',
+  '**/*.min.json',
   '**/examples/**',
   '**/assets/**'
 ];


### PR DESCRIPTION
## Summary
- remove blanket ignores for *.json and *.sh so configs and scripts are indexed
- keep lockfiles and minified JSON excluded to avoid noise

Closes #33