### PR TITLE
Constrain logger metadata types

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -13,8 +13,10 @@ export enum LogLevel {
   SILENT = 4,
 }
 
+export type LogValue = string | number | boolean | null | undefined | LogValue[] | { [key: string]: LogValue };
+
 interface LogMetadata {
-  [key: string]: any;
+  [key: string]: LogValue;
 }
 
 class Logger {


### PR DESCRIPTION
## Summary
- limit logger metadata to serializable primitive/array/object values via LogValue type

Closes #30