### PR TITLE
Add transactional batch inserts for indexing

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -20,7 +20,10 @@ export function readGlobalConfig(): CodevaultConfig | null {
     const content = fs.readFileSync(GLOBAL_CONFIG_FILE, 'utf8');
     return JSON.parse(content);
   } catch (error) {
-    log.warn('Failed to read global config', { error, path: GLOBAL_CONFIG_FILE });
+    log.warn('Failed to read global config', {
+      error: error instanceof Error ? error.message : String(error),
+      path: GLOBAL_CONFIG_FILE
+    });
     return null;
   }
 }
@@ -39,7 +42,11 @@ export function readProjectConfig(basePath = '.'): CodevaultConfig | null {
     return JSON.parse(content);
   } catch (error) {
     const configPath = path.join(path.resolve(basePath), PROJECT_CONFIG_FILE);
-    log.warn('Failed to read project config', { error, path: configPath, basePath });
+    log.warn('Failed to read project config', {
+      error: error instanceof Error ? error.message : String(error),
+      path: configPath,
+      basePath
+    });
     return null;
   }
 }

--- a/src/core/batch-indexer.ts
+++ b/src/core/batch-indexer.ts
@@ -153,30 +153,25 @@ export class BatchEmbeddingProcessor {
     log.debug(`Batch complete (${texts.length} embeddings generated)`);
 
     // Store all embeddings in database within a transaction
-    await this.db.transaction(() => {
-      for (let i = 0; i < batch.length; i++) {
-        const chunk = batch[i];
-        const embedding = embeddings[i];
-
-        this.db.insertChunk({
-          id: chunk.chunkId,
-          file_path: chunk.params.rel,
-          symbol: chunk.params.symbol,
-          sha: chunk.params.sha,
-          lang: chunk.params.lang,
-          chunk_type: chunk.params.chunkType,
-          embedding,
-          embedding_provider: this.embeddingProvider.getName(),
-          embedding_dimensions: this.embeddingProvider.getDimensions(),
-          codevault_tags: chunk.params.codevaultMetadata.tags,
-          codevault_intent: chunk.params.codevaultMetadata.intent,
-          codevault_description: chunk.params.codevaultMetadata.description,
-          doc_comments: chunk.params.docComments,
-          variables_used: chunk.params.importantVariables,
-          context_info: chunk.params.contextInfo
-        });
-      }
-    });
+    this.db.insertChunks(
+      batch.map((chunk, i) => ({
+        id: chunk.chunkId,
+        file_path: chunk.params.rel,
+        symbol: chunk.params.symbol,
+        sha: chunk.params.sha,
+        lang: chunk.params.lang,
+        chunk_type: chunk.params.chunkType,
+        embedding: embeddings[i],
+        embedding_provider: this.embeddingProvider.getName(),
+        embedding_dimensions: this.embeddingProvider.getDimensions(),
+        codevault_tags: chunk.params.codevaultMetadata.tags,
+        codevault_intent: chunk.params.codevaultMetadata.intent,
+        codevault_description: chunk.params.codevaultMetadata.description,
+        doc_comments: chunk.params.docComments,
+        variables_used: chunk.params.importantVariables,
+        context_info: chunk.params.contextInfo
+      }))
+    );
   }
 
   /**

--- a/src/core/indexing/IndexFinalizationStage.ts
+++ b/src/core/indexing/IndexFinalizationStage.ts
@@ -81,7 +81,7 @@ export class IndexFinalizationStage {
   private logStatistics(): void {
     if (!process.env.CODEVAULT_QUIET) {
       logger.info('Chunking Statistics', {
-        stats: this.state.chunkingStats,
+        stats: { ...this.state.chunkingStats },
         processedChunks: this.state.processedChunks,
         totalChunks: Object.keys(this.state.codemap).length
       });

--- a/src/core/search/CandidateRetriever.ts
+++ b/src/core/search/CandidateRetriever.ts
@@ -80,7 +80,7 @@ export class CandidateRetriever {
         } catch (error) {
           logger.warn('Failed to parse codevault_tags for chunk', {
             chunkId: chunk.id,
-            error
+            error: error instanceof Error ? error.message : String(error)
           });
         }
       }

--- a/src/storage/encrypted-chunks.ts
+++ b/src/storage/encrypted-chunks.ts
@@ -40,7 +40,9 @@ function decodeKey(raw: string): Buffer | null {
       return base64;
     }
   } catch (error) {
-    log.debug('Failed to decode key as base64, will try hex', { error });
+    log.debug('Failed to decode key as base64, will try hex', {
+      error: error instanceof Error ? error.message : String(error)
+    });
   }
 
   try {
@@ -49,7 +51,9 @@ function decodeKey(raw: string): Buffer | null {
       return hex;
     }
   } catch (error) {
-    log.debug('Failed to decode key as hex', { error });
+    log.debug('Failed to decode key as hex', {
+      error: error instanceof Error ? error.message : String(error)
+    });
   }
 
   return null;


### PR DESCRIPTION
## Summary
- add insertChunks for atomic batch writes using better-sqlite3 transactions
- switch batch embedding pipeline to use chunk batch inserts instead of per-row writes
- adjust logger metadata usage to stay serializable with stricter LogValue typing

Closes #11