### PR TITLE
Prevent async misuse in database transactions

### DIFF
--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -511,8 +511,14 @@ export class CodeVaultDatabase {
    * better-sqlite3 transactions must be synchronous; do async work before/after.
    */
   transaction<T>(fn: () => T): T {
-    const run = this.db.transaction(fn);
-    return run();
+    const wrapped = this.db.transaction(() => {
+      const result = fn();
+      if (result && typeof (result as any).then === 'function') {
+        throw new Error('better-sqlite3 transactions must be synchronous; avoid returning a Promise.');
+      }
+      return result;
+    });
+    return wrapped();
   }
 
   /**


### PR DESCRIPTION
## Summary
- enforce synchronous better-sqlite3 transactions by rejecting Promise-returning callbacks
- keep transaction helper aligned with library requirements to avoid premature commits

Closes #16